### PR TITLE
Adds ability to select and drag multiple nodes.

### DIFF
--- a/src/node-renderer-default.js
+++ b/src/node-renderer-default.js
@@ -24,7 +24,7 @@ const NodeRendererDefault = ({
     isOver,
     canDrop,
     node,
-    draggedNode,
+    draggedNodes,
     path,
     treeIndex,
     isSearchMatch,
@@ -34,6 +34,7 @@ const NodeRendererDefault = ({
     style = {},
     startDrag: _startDrag,
     endDrag: _endDrag,
+    selectNode = () => {},
     ...otherProps,
 }) => {
     let handle;
@@ -59,13 +60,18 @@ const NodeRendererDefault = ({
             </div>
         );
     } else {
+        const handleSelect = event => selectNode({node, path, event});
+
         // Show the handle used to initiate a drag-and-drop
         handle = connectDragSource((
-            <div className={styles.moveHandle} />
+            <button
+                className={styles.moveHandle + (node.selected ? ` ${styles.selected}` : '')}
+                onClick={handleSelect}
+            />
         ), { dropEffect: 'copy' });
     }
 
-    const isDraggedDescendant = draggedNode && isDescendant(draggedNode, node);
+    const isDraggedDescendant = draggedNodes && draggedNodes.some(draggedNode => isDescendant(draggedNode, node));
 
     return (
         <div
@@ -166,10 +172,13 @@ NodeRendererDefault.propTypes = {
     startDrag:          PropTypes.func.isRequired, // Needed for drag-and-drop utils
     endDrag:            PropTypes.func.isRequired, // Needed for drag-and-drop utils
     isDragging:         PropTypes.bool.isRequired,
-    draggedNode:        PropTypes.object,
+    draggedNodes:       PropTypes.arrayOf(PropTypes.object),
     // Drop target
     isOver:  PropTypes.bool.isRequired,
     canDrop: PropTypes.bool.isRequired,
+
+    // Select API functions
+    selectNode: PropTypes.func,
 };
 
 export default NodeRendererDefault;

--- a/src/node-renderer-default.scss
+++ b/src/node-renderer-default.scss
@@ -113,6 +113,10 @@ $row-padding: 10px;
     z-index: 1;
 }
 
+.moveHandle.selected {
+    background-color: #D9D9FF;
+}
+
 .loadingHandle {
     @extend .moveHandle;
 

--- a/src/tree-node.js
+++ b/src/tree-node.js
@@ -11,7 +11,7 @@ const TreeNode = ({
     lowerSiblingCounts,
     connectDropTarget,
     isOver,
-    draggedNode,
+    draggedNodes,
     canDrop,
     treeIndex,
     getPrevRow: _getPrevRow, // Delete from otherProps
@@ -124,7 +124,7 @@ const TreeNode = ({
                 {Children.map(children, child => cloneElement(child, {
                     isOver,
                     canDrop,
-                    draggedNode,
+                    draggedNodes,
                 }))}
             </div>
         </div>
@@ -148,7 +148,7 @@ TreeNode.propTypes = {
     connectDropTarget: PropTypes.func.isRequired,
     isOver:            PropTypes.bool.isRequired,
     canDrop:           PropTypes.bool.isRequired,
-    draggedNode:       PropTypes.object,
+    draggedNodes:      PropTypes.arrayOf(PropTypes.object),
 };
 
 export default TreeNode;

--- a/src/utils/drag-and-drop-utils.js
+++ b/src/utils/drag-and-drop-utils.js
@@ -74,7 +74,7 @@ function canDrop(dropTargetProps, monitor, isHover = false) {
         typeof aboveNode.children !== 'function'
     ) && (
         // Ignore when hovered above the identical node...
-        !(draggedNodes.length === 1 && dropTargetProps.node === draggedNodes[0] && isHover === true) ||
+        !(dropTargetProps.node === draggedNodes[0] && isHover === true) ||
         // ...unless it's at a different level than the current one
         targetDepth !== (dropTargetProps.path.length - 1)
     );


### PR DESCRIPTION
This pull request is a basic implementation of #11. The preview while dragging is not as good as I'd like, but I'm new to React and don't know how to customise the drag preview without changing the rendered rows (e.g. by ensuring that the screenshot is always from one of the root nodes, even when dragging starts on a child).
It works, but I'm happy to improve my implementation if you can point me at possible improvements.