### PR TITLE
chore: bump react-dnd deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4926,14 +4926,14 @@
       "dev": true
     },
     "disposables": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/disposables/-/disposables-1.0.1.tgz",
-      "integrity": "sha1-BkcnoltU9QK9griaot+4358bOeM="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/disposables/-/disposables-1.0.2.tgz",
+      "integrity": "sha1-NsamdEdfVaLWkTVnpgFETkh7S24="
     },
     "dnd-core": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.5.4.tgz",
-      "integrity": "sha512-BcI782MfTm3wCxeIS5c7tAutyTwEIANtuu3W6/xkoJRwiqhRXKX3BbGlycUxxyzMsKdvvoavxgrC3EMPFNYL9A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.6.0.tgz",
+      "integrity": "sha1-ErrWbVh0LG5ffPKUP7aFlED4CcQ=",
       "requires": {
         "asap": "2.0.6",
         "invariant": "2.2.2",
@@ -7955,9 +7955,9 @@
       "dev": true
     },
     "hoist-non-react-statics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+      "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -13902,22 +13902,22 @@
       "integrity": "sha1-9QIE1DDJyoGbwLreAwbpF12NGYc="
     },
     "react-dnd": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.5.4.tgz",
-      "integrity": "sha512-y9YmnusURc+3KPgvhYKvZ9oCucj51MSZWODyaeV0KFU0cquzA7dCD1g/OIYUKtNoZ+MXtacDngkdud2TklMSjw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.6.0.tgz",
+      "integrity": "sha1-f6JWds+CfViokSk+PBq1naACVFo=",
       "requires": {
-        "disposables": "1.0.1",
-        "dnd-core": "2.5.4",
-        "hoist-non-react-statics": "2.3.1",
+        "disposables": "1.0.2",
+        "dnd-core": "2.6.0",
+        "hoist-non-react-statics": "2.5.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4",
         "prop-types": "15.6.1"
       }
     },
     "react-dnd-html5-backend": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.5.4.tgz",
-      "integrity": "sha512-jDqAkm/hI8Tl4HcsbhkBgB6HgpJR1e+ML1SbfxaegXYiuMxEVQm0FOwEH5WxUoo6fmIG4N+H0rSm59POuZOCaA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.6.0.tgz",
+      "integrity": "sha1-WQzRzKeEQbsnTt1XH+9MCxbdz44=",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -13971,7 +13971,7 @@
       "dev": true,
       "requires": {
         "invariant": "2.2.2",
-        "react-dnd": "2.5.4"
+        "react-dnd": "2.6.0"
       }
     },
     "react-docgen": {
@@ -14120,6 +14120,31 @@
         "react-dnd-html5-backend": "2.5.4",
         "react-dnd-scrollzone": "4.0.0",
         "react-virtualized": "9.18.5"
+      },
+      "dependencies": {
+        "react-dnd": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.5.4.tgz",
+          "integrity": "sha512-y9YmnusURc+3KPgvhYKvZ9oCucj51MSZWODyaeV0KFU0cquzA7dCD1g/OIYUKtNoZ+MXtacDngkdud2TklMSjw==",
+          "dev": true,
+          "requires": {
+            "disposables": "1.0.2",
+            "dnd-core": "2.6.0",
+            "hoist-non-react-statics": "2.5.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4",
+            "prop-types": "15.6.1"
+          }
+        },
+        "react-dnd-html5-backend": {
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.5.4.tgz",
+          "integrity": "sha512-jDqAkm/hI8Tl4HcsbhkBgB6HgpJR1e+ML1SbfxaegXYiuMxEVQm0FOwEH5WxUoo6fmIG4N+H0rSm59POuZOCaA==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
       }
     },
     "react-split-pane": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
   "dependencies": {
     "lodash.isequal": "^4.4.0",
     "prop-types": "^15.6.1",
-    "react-dnd": "2.5.4",
-    "react-dnd-html5-backend": "2.5.4",
+    "react-dnd": "2.6.x",
+    "react-dnd-html5-backend": "2.6.x",
     "react-dnd-scrollzone": "^4.0.0",
     "react-virtualized": "^9.18.5"
   },


### PR DESCRIPTION
Tests pass, and I manually walked through the storybook examples to make sure they all work.

I noticed #161, where you moved from a wide version range to an exact version. I think pegging to the minor value (what I've done here) is a nice middle ground, and helps reduce the change that DND will be included twice in the user's bundled code (happening to us now). Thoughts?