### PR TITLE
Added example of expand lazy loading to storybook advanced section

### DIFF
--- a/examples/storybooks/__snapshots__/storyshots.test.js.snap
+++ b/examples/storybooks/__snapshots__/storyshots.test.js.snap
@@ -724,6 +724,347 @@ exports[`Storyshots Advanced Drag out to remove 1`] = `
 </div>
 `;
 
+exports[`Storyshots Advanced Expand with lazy loading of child nodes 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "height": 300,
+      }
+    }
+  >
+    <div
+      className="rst__tree"
+      style={
+        Object {
+          "height": "100%",
+        }
+      }
+    >
+      <div>
+        <div
+          aria-label="grid"
+          aria-readonly={true}
+          className="ReactVirtualized__Grid ReactVirtualized__List rst__virtualScrollOverride"
+          id={undefined}
+          onScroll={[Function]}
+          role="grid"
+          style={
+            Object {
+              "WebkitOverflowScrolling": "touch",
+              "boxSizing": "border-box",
+              "direction": "ltr",
+              "height": 99999,
+              "overflowX": "hidden",
+              "overflowY": "hidden",
+              "position": "relative",
+              "width": 200,
+              "willChange": "transform",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="ReactVirtualized__Grid__innerScrollContainer"
+            role="rowgroup"
+            style={
+              Object {
+                "height": 186,
+                "maxHeight": 186,
+                "maxWidth": 200,
+                "overflow": "hidden",
+                "pointerEvents": "",
+                "position": "relative",
+                "width": "auto",
+              }
+            }
+          >
+            <div
+              className="rst__node"
+              style={
+                Object {
+                  "height": 62,
+                  "left": 0,
+                  "position": "absolute",
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                className="rst__lineBlock rst__lineHalfHorizontalRight rst__lineHalfVerticalBottom"
+                style={
+                  Object {
+                    "width": 44,
+                  }
+                }
+              />
+              <div
+                className="rst__nodeContent"
+                style={
+                  Object {
+                    "left": 44,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                >
+                  <div>
+                    <button
+                      aria-label="Collapse"
+                      className="rst__collapseButton"
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "left": -22,
+                        }
+                      }
+                      type="button"
+                    />
+                    <div
+                      className="rst__lineChildren"
+                      style={
+                        Object {
+                          "width": 44,
+                        }
+                      }
+                    />
+                  </div>
+                  <div
+                    className="rst__rowWrapper"
+                  >
+                    <div
+                      className="rst__row"
+                      style={
+                        Object {
+                          "opacity": 1,
+                        }
+                      }
+                    >
+                      <div
+                        className="rst__moveHandle"
+                      />
+                      <div
+                        className="rst__rowContents"
+                      >
+                        <div
+                          className="rst__rowLabel"
+                        >
+                          <span
+                            className="rst__rowTitle"
+                          >
+                            Chicken
+                          </span>
+                        </div>
+                        <div
+                          className="rst__rowToolbar"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="rst__node"
+              style={
+                Object {
+                  "height": 62,
+                  "left": 0,
+                  "position": "absolute",
+                  "top": 62,
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                className="rst__lineBlock rst__lineFullVertical"
+                style={
+                  Object {
+                    "width": 44,
+                  }
+                }
+              />
+              <div
+                className="rst__lineBlock rst__lineHalfVerticalTop rst__lineHalfHorizontalRight"
+                style={
+                  Object {
+                    "width": 44,
+                  }
+                }
+              />
+              <div
+                className="rst__nodeContent"
+                style={
+                  Object {
+                    "left": 88,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                >
+                  <div
+                    className="rst__rowWrapper"
+                  >
+                    <div
+                      className="rst__row"
+                      style={
+                        Object {
+                          "opacity": 1,
+                        }
+                      }
+                    >
+                      <div
+                        className="rst__moveHandle"
+                      />
+                      <div
+                        className="rst__rowContents"
+                      >
+                        <div
+                          className="rst__rowLabel"
+                        >
+                          <span
+                            className="rst__rowTitle"
+                          >
+                            Egg
+                          </span>
+                        </div>
+                        <div
+                          className="rst__rowToolbar"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="rst__node"
+              style={
+                Object {
+                  "height": 62,
+                  "left": 0,
+                  "position": "absolute",
+                  "top": 124,
+                  "width": "100%",
+                }
+              }
+            >
+              <div
+                className="rst__lineBlock rst__lineHalfVerticalTop rst__lineHalfHorizontalRight"
+                style={
+                  Object {
+                    "width": 44,
+                  }
+                }
+              />
+              <div
+                className="rst__nodeContent"
+                style={
+                  Object {
+                    "left": 44,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": "100%",
+                    }
+                  }
+                >
+                  <div>
+                    <button
+                      aria-label="Expand"
+                      className="rst__expandButton"
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "left": -22,
+                        }
+                      }
+                      type="button"
+                    />
+                  </div>
+                  <div
+                    className="rst__rowWrapper"
+                  >
+                    <div
+                      className="rst__row"
+                      style={
+                        Object {
+                          "opacity": 1,
+                        }
+                      }
+                    >
+                      <div
+                        className="rst__moveHandle"
+                      />
+                      <div
+                        className="rst__rowContents"
+                      >
+                        <div
+                          className="rst__rowLabel"
+                        >
+                          <span
+                            className="rst__rowTitle"
+                          >
+                            Spaceship
+                          </span>
+                        </div>
+                        <div
+                          className="rst__rowToolbar"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <br />
+  <form
+    action="https://codesandbox.io/api/v1/sandboxes/define"
+    id="codesandbox-form"
+    method="POST"
+  >
+    <input
+      id="codesandbox-parameters"
+      name="parameters"
+      type="hidden"
+    />
+  </form>
+  <button
+    className="sandboxButton"
+    onClick={[Function]}
+  >
+    PLAY WITH THIS CODE →
+  </button>
+  <a
+    className="sourceLink"
+    href="https://github.com/frontend-collective/react-sortable-tree/blob/master/examples/storybooks/expand-lazy-loading.js"
+    rel="noopener noreferrer"
+    target="_top"
+  >
+    VIEW SOURCE →
+  </a>
+</div>
+`;
+
 exports[`Storyshots Advanced Playing with generateNodeProps 1`] = `
 <div>
   <div>

--- a/examples/storybooks/expand-lazy-loading.js
+++ b/examples/storybooks/expand-lazy-loading.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import SortableTree from '../../src';
+// In your own app, you would need to use import styles once in the app
+// import 'react-sortable-tree/styles.css';
+
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      treeData: [
+        { title: 'Chicken', expanded: true, children: [{ title: 'Egg' }] },
+        {
+          title: 'Spaceship',
+          children: ({ done }) => {
+            setTimeout(() => {
+              done([
+                { title: 'Orbiter' },
+                { title: 'Main Engines' },
+                { title: 'External Tank' },
+                { title: 'Solid Rocket Boosters' },
+              ]);
+            }, 1000);
+          },
+        },
+      ],
+    };
+  }
+
+  render() {
+    return (
+      <div style={{ height: 300 }}>
+        <SortableTree
+          treeData={this.state.treeData}
+          onChange={treeData => this.setState({ treeData })}
+        />
+      </div>
+    );
+  }
+}

--- a/examples/storybooks/index.js
+++ b/examples/storybooks/index.js
@@ -15,6 +15,7 @@ import ThemesExample from './themes';
 import TouchSupportExample from './touch-support';
 import TreeDataIOExample from './tree-data-io';
 import TreeToTreeExample from './tree-to-tree';
+import ExpandLazyLoadingExample from './expand-lazy-loading';
 import './generic.css';
 
 import { handleClick, SANDBOX_URL } from './sandbox-utils';
@@ -74,4 +75,7 @@ storiesOf('Advanced', module)
   )
   .add('Drag out to remove', () =>
     wrapWithSource(<DragOutToRemoveExample />, 'drag-out-to-remove.js')
+  )
+  .add('Expand with lazy loading of child nodes', () =>
+    wrapWithSource(<ExpandLazyLoadingExample />, 'expand-lazy-loading.js')
   );


### PR DESCRIPTION
This is an example for lazy loading of child nodes during expand.
I have added this example for further illustration of an annoying bug in this area when you try to drag into not expanded (and thus not loaded yet) node.
This is related to issue [211](https://github.com/frontend-collective/react-sortable-tree/issues/211) and my closed PR [227](https://github.com/frontend-collective/react-sortable-tree/pull/227) which I am going to recreate later.