### PR TITLE
Add addAsFirstChild option to addNodeUnderParent

### DIFF
--- a/src/utils/tree-data-utils.js
+++ b/src/utils/tree-data-utils.js
@@ -60,7 +60,7 @@ function getNodeDataAtTreeIndexOrNextIndex({
 export function getDescendantCount({ node, ignoreCollapsed = true }) {
   return (
     getNodeDataAtTreeIndexOrNextIndex({
-      getNodeKey: () => {},
+      getNodeKey: () => { },
       ignoreCollapsed,
       node,
       currentIndex: 0,
@@ -106,12 +106,12 @@ function walkDescendants({
   const selfInfo = isPseudoRoot
     ? null
     : {
-        node,
-        parentNode,
-        path: selfPath,
-        lowerSiblingCounts,
-        treeIndex: currentIndex,
-      };
+      node,
+      parentNode,
+      path: selfPath,
+      lowerSiblingCounts,
+      treeIndex: currentIndex,
+    };
 
   if (!isPseudoRoot) {
     const callbackResult = callback(selfInfo);
@@ -604,6 +604,7 @@ export function getNodeAtPath({
  * @param {!function} getNodeKey - Function to get the key from the nodeData and tree index
  * @param {boolean=} ignoreCollapsed - Ignore children of nodes without `expanded` set to `true`
  * @param {boolean=} expandParent - If true, expands the parentNode specified by parentPath
+ * @param {boolean=} addAsFirstChild - If true, adds new node as first child of tree
  *
  * @return {Object} result
  * @return {Object[]} result.treeData - The updated tree data
@@ -670,7 +671,7 @@ export function addNodeUnderParent({
       insertedTreeIndex = nextTreeIndex;
 
       const children = addAsFirstChild
-        ? [ newNode, ...parentNode.children]
+        ? [newNode, ...parentNode.children]
         : [...parentNode.children, newNode];
 
       return {
@@ -885,7 +886,7 @@ export function insertNode({
   depth: targetDepth,
   minimumTreeIndex,
   newNode,
-  getNodeKey = () => {},
+  getNodeKey = () => { },
   ignoreCollapsed = true,
   expandParent = false,
 }) {
@@ -1093,9 +1094,9 @@ export function find({
     const extraInfo = isPseudoRoot
       ? null
       : {
-          path: selfPath,
-          treeIndex: currentIndex,
-        };
+        path: selfPath,
+        treeIndex: currentIndex,
+      };
 
     // Nodes with with children that aren't lazy
     const hasChildren =

--- a/src/utils/tree-data-utils.js
+++ b/src/utils/tree-data-utils.js
@@ -60,7 +60,7 @@ function getNodeDataAtTreeIndexOrNextIndex({
 export function getDescendantCount({ node, ignoreCollapsed = true }) {
   return (
     getNodeDataAtTreeIndexOrNextIndex({
-      getNodeKey: () => { },
+      getNodeKey: () => {},
       ignoreCollapsed,
       node,
       currentIndex: 0,
@@ -106,12 +106,12 @@ function walkDescendants({
   const selfInfo = isPseudoRoot
     ? null
     : {
-      node,
-      parentNode,
-      path: selfPath,
-      lowerSiblingCounts,
-      treeIndex: currentIndex,
-    };
+        node,
+        parentNode,
+        path: selfPath,
+        lowerSiblingCounts,
+        treeIndex: currentIndex,
+      };
 
   if (!isPseudoRoot) {
     const callbackResult = callback(selfInfo);
@@ -886,7 +886,7 @@ export function insertNode({
   depth: targetDepth,
   minimumTreeIndex,
   newNode,
-  getNodeKey = () => { },
+  getNodeKey = () => {},
   ignoreCollapsed = true,
   expandParent = false,
 }) {
@@ -1094,9 +1094,9 @@ export function find({
     const extraInfo = isPseudoRoot
       ? null
       : {
-        path: selfPath,
-        treeIndex: currentIndex,
-      };
+          path: selfPath,
+          treeIndex: currentIndex,
+        };
 
     // Nodes with with children that aren't lazy
     const hasChildren =

--- a/src/utils/tree-data-utils.js
+++ b/src/utils/tree-data-utils.js
@@ -616,6 +616,7 @@ export function addNodeUnderParent({
   getNodeKey,
   ignoreCollapsed = true,
   expandParent = false,
+  addAsFirstChild = false,
 }) {
   if (parentKey === null) {
     return {
@@ -668,9 +669,13 @@ export function addNodeUnderParent({
 
       insertedTreeIndex = nextTreeIndex;
 
+      const children = addAsFirstChild
+        ? [ newNode, ...parentNode.children]
+        : [...parentNode.children, newNode];
+
       return {
         ...parentNode,
-        children: [...parentNode.children, newNode],
+        children,
       };
     },
   });

--- a/src/utils/tree-data-utils.test.js
+++ b/src/utils/tree-data-utils.test.js
@@ -1120,10 +1120,16 @@ describe('addNodeUnderParent', () => {
       getNodeKey: keyFromKey,
     });
 
-    const [existingChild0, existingChild1, expectedNewNode] = result.treeData[0].children;
+    const [
+      existingChild0,
+      existingChild1,
+      expectedNewNode,
+    ] = result.treeData[0].children;
 
     expect(expectedNewNode).toEqual(nestedParams.newNode);
-    expect([existingChild0, existingChild1]).toEqual(nestedParams.treeData[0].children);
+    expect([existingChild0, existingChild1]).toEqual(
+      nestedParams.treeData[0].children
+    );
   });
 
   it('should add new node as first child if addAsFirstChild is true', () => {

--- a/src/utils/tree-data-utils.test.js
+++ b/src/utils/tree-data-utils.test.js
@@ -1112,6 +1112,33 @@ describe('addNodeUnderParent', () => {
     );
     expect(result.treeIndex).toEqual(5);
   });
+
+  it('should add new node as last child by default', () => {
+    const result = addNodeUnderParent({
+      ...nestedParams,
+      parentKey: 0,
+      getNodeKey: keyFromKey,
+    });
+
+    const [existingChild0, existingChild1, expectedNewNode] = result.treeData[0].children;
+
+    expect(expectedNewNode).toEqual(nestedParams.newNode);
+    expect([existingChild0, existingChild1]).toEqual(nestedParams.treeData[0].children);
+  });
+
+  it('should add new node as first child if addAsFirstChild is true', () => {
+    const result = addNodeUnderParent({
+      ...nestedParams,
+      parentKey: 0,
+      getNodeKey: keyFromKey,
+      addAsFirstChild: true,
+    });
+
+    const [expectedNewNode, ...previousChildren] = result.treeData[0].children;
+
+    expect(expectedNewNode).toEqual(nestedParams.newNode);
+    expect(previousChildren).toEqual(nestedParams.treeData[0].children);
+  });
 });
 
 describe('insertNode', () => {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -2243,6 +2243,18 @@ exports[`Storyshots Basics Add and remove nodes programmatically 1`] = `
     >
       Add more
     </button>
+    <br />
+    <label
+      Htmlfor="addAsFirstChild"
+    >
+      Add new nodes at start
+      <input
+        checked={false}
+        name="addAsFirstChild"
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </label>
   </div>
   <br />
   <form

--- a/stories/add-remove.js
+++ b/stories/add-remove.js
@@ -132,9 +132,11 @@ export default class App extends Component {
             name="addAsFirstChild"
             type="checkbox"
             checked={this.state.addAsFirstChild}
-            onChange={() => this.setState(state => ({
-              addAsFirstChild: !state.addAsFirstChild,
-            }))}
+            onChange={() =>
+              this.setState(state => ({
+                addAsFirstChild: !state.addAsFirstChild,
+              }))
+            }
           />
         </label>
       </div>

--- a/stories/add-remove.js
+++ b/stories/add-remove.js
@@ -60,6 +60,7 @@ export default class App extends Component {
 
     this.state = {
       treeData: [{ title: 'Peter Olofsson' }, { title: 'Karl Johansson' }],
+      addAsFirstChild: false,
     };
   }
 
@@ -88,6 +89,7 @@ export default class App extends Component {
                             node.title.split(' ')[0]
                           }sson`,
                         },
+                        addAsFirstChild: state.addAsFirstChild,
                       }).treeData,
                     }))
                   }
@@ -123,6 +125,18 @@ export default class App extends Component {
         >
           Add more
         </button>
+        <br />
+        <label Htmlfor="addAsFirstChild">
+          Add new nodes at start
+          <input
+            name="addAsFirstChild"
+            type="checkbox"
+            checked={this.state.addAsFirstChild}
+            onChange={() => this.setState(state => ({
+              addAsFirstChild: !state.addAsFirstChild,
+            }))}
+          />
+        </label>
       </div>
     );
   }


### PR DESCRIPTION
Adds the option `addAsFirstChild` to the config object of `addNodeUnderParent`. Setting this option true will add the new node at the beginning of `children` rather than the end.

```
const children = addAsFirstChild
        ? [ newNode, ...parentNode.children]
        : [...parentNode.children, newNode];
```

Basic tests and an option in storybook added. 

Fixes #389 