### PR TITLE
Childless Nodes

### DIFF
--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -479,6 +479,14 @@ class ReactSortableTree extends Component {
     this.moveNode(dropResult);
   }
 
+  canNodeHaveChildren(node) {
+    const { canNodeHaveChildren } = this.props;
+    if (canNodeHaveChildren) {
+      return canNodeHaveChildren(node);
+    }
+    return true;
+  }
+
   // Load any children in the tree that are given by a function
   // calls the onChange callback on the new treeData
   static loadLazyChildren(props, state) {

--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -867,6 +867,9 @@ ReactSortableTree.propTypes = {
   // Determine whether a node can be dropped based on its path and parents'.
   canDrop: PropTypes.func,
 
+  // Determine whether a node can have children
+  canNodeHaveChildren: PropTypes.func,
+
   // When true, or a callback returning true, dropping nodes to react-dnd
   // drop targets outside of this tree will not remove them from this tree
   shouldCopyOnOutsideDrop: PropTypes.oneOfType([
@@ -892,6 +895,7 @@ ReactSortableTree.propTypes = {
 ReactSortableTree.defaultProps = {
   canDrag: true,
   canDrop: null,
+  canNodeHaveChildren: () => true,
   className: '',
   dndType: null,
   generateNodeProps: null,

--- a/src/utils/dnd-manager.js
+++ b/src/utils/dnd-manager.js
@@ -62,9 +62,15 @@ export default class DndManager {
 
     const rowAbove = dropTargetProps.getPrevRow();
     if (rowAbove) {
+      let { path } = rowAbove;
+      const aboveNodeCannotHaveChildren = !this.treeRef.canNodeHaveChildren(rowAbove.node);
+      if (aboveNodeCannotHaveChildren) {
+        path = path.slice(0, path.length - 1);
+      }
+
       // Limit the length of the path to the deepest possible
       dropTargetDepth = Math.min(
-        rowAbove.path.length,
+        path.length,
         dropTargetProps.path.length
       );
     }

--- a/stories/childless-nodes.js
+++ b/stories/childless-nodes.js
@@ -1,0 +1,73 @@
+import React, { Component } from 'react';
+import SortableTree, { changeNodeAtPath } from '../src';
+// In your own app, you would need to use import styles once in the app
+// import 'react-sortable-tree/styles.css';
+
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      treeData: [{
+        name: 'Managers',
+        expanded: true,
+        children: [{
+          name: 'Rob',
+          children: [],
+          hasNoChildren: true
+        }, {
+          name: 'Joe',
+          children: [],
+          hasNoChildren: true
+        }]
+      }, {
+        name: 'Clerks',
+        expanded: true,
+        children: [{
+          name: 'Bertha',
+          children: [],
+          hasNoChildren: true
+        }, {
+          name: 'Billy',
+          children: [],
+          hasNoChildren: true
+        }]
+      }],
+    };
+  }
+
+  render() {
+    const getNodeKey = ({ treeIndex }) => treeIndex;
+    return (
+      <div>
+        <div style={{ height: 300 }}>
+          <SortableTree
+            treeData={this.state.treeData}
+            canNodeHaveChildren={node => !node.hasNoChildren}
+            onChange={treeData => this.setState({ treeData })}
+            generateNodeProps={({ node, path }) => ({
+              title: (
+                <input
+                  style={{ fontSize: '1.1rem' }}
+                  value={node.name}
+                  onChange={event => {
+                    const name = event.target.value;
+
+                    this.setState(state => ({
+                      treeData: changeNodeAtPath({
+                        treeData: state.treeData,
+                        path,
+                        getNodeKey,
+                        newNode: { ...node, name },
+                      }),
+                    }));
+                  }}
+                />
+              ),
+            })}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/stories/childless-nodes.js
+++ b/stories/childless-nodes.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import SortableTree, { changeNodeAtPath } from '../src';
+import SortableTree from '../src';
 // In your own app, you would need to use import styles once in the app
 // import 'react-sortable-tree/styles.css';
 
@@ -9,26 +9,26 @@ export default class App extends Component {
 
     this.state = {
       treeData: [{
-        name: 'Managers',
+        title: 'Managers',
         expanded: true,
         children: [{
-          name: 'Rob',
+          title: 'Rob',
           children: [],
           hasNoChildren: true
         }, {
-          name: 'Joe',
+          title: 'Joe',
           children: [],
           hasNoChildren: true
         }]
       }, {
-        name: 'Clerks',
+        title: 'Clerks',
         expanded: true,
         children: [{
-          name: 'Bertha',
+          title: 'Bertha',
           children: [],
           hasNoChildren: true
         }, {
-          name: 'Billy',
+          title: 'Billy',
           children: [],
           hasNoChildren: true
         }]
@@ -37,7 +37,6 @@ export default class App extends Component {
   }
 
   render() {
-    const getNodeKey = ({ treeIndex }) => treeIndex;
     return (
       <div>
         <div style={{ height: 300 }}>
@@ -45,26 +44,6 @@ export default class App extends Component {
             treeData={this.state.treeData}
             canNodeHaveChildren={node => !node.hasNoChildren}
             onChange={treeData => this.setState({ treeData })}
-            generateNodeProps={({ node, path }) => ({
-              title: (
-                <input
-                  style={{ fontSize: '1.1rem' }}
-                  value={node.name}
-                  onChange={event => {
-                    const name = event.target.value;
-
-                    this.setState(state => ({
-                      treeData: changeNodeAtPath({
-                        treeData: state.treeData,
-                        path,
-                        getNodeKey,
-                        newNode: { ...node, name },
-                      }),
-                    }));
-                  }}
-                />
-              ),
-            })}
           />
         </div>
       </div>

--- a/stories/index.js
+++ b/stories/index.js
@@ -6,6 +6,7 @@ import AddRemoveExample from './add-remove';
 import BarebonesExample from './barebones';
 import CallbacksExample from './callbacks';
 import CanDropExample from './can-drop';
+import ChildlessNodes from './childless-nodes';
 import DragOutToRemoveExample from './drag-out-to-remove';
 import ExternalNodeExample from './external-node';
 import GenerateNodePropsExample from './generate-node-props';
@@ -86,3 +87,8 @@ storiesOf('Advanced', module)
       'only-expand-searched-node.js'
     )
   );
+
+storiesOf('Custom', module)
+  .add('Some nodes should not preview drop as child', () =>
+    wrapWithSource(<ChildlessNodes />, 'childless-nodes.js')
+  )

--- a/stories/index.js
+++ b/stories/index.js
@@ -86,9 +86,7 @@ storiesOf('Advanced', module)
       <OnlyExpandSearchedNodesExample />,
       'only-expand-searched-node.js'
     )
-  );
-
-storiesOf('Custom', module)
-  .add('Some nodes should not preview drop as child', () =>
-    wrapWithSource(<ChildlessNodes />, 'childless-nodes.js')
   )
+  .add('Prevent some nodes from having children', () =>
+    wrapWithSource(<ChildlessNodes />, 'childless-nodes.js')
+  );


### PR DESCRIPTION
Let me know if there is any additional information you need, either in this PR or about these changes!


We're looking to utilize this awesome package, but we need an additional feature. The filesystem theme is great, but you can preview dropping a file into another file. This drop is rejected, which is nice, but we shouldn't really allow users to preview a file being underneath another file. The custom hover implementation is awesome, and adding a little more control over the hover state would allow us to use the package to the fullest extent. 

Did some digging to try and figure out where this change would be sensible. Having a parameter to the `SortableTree` would be nice, and it needs to be called over in the `dndManager`. So I added the `canNodeHaveChildren` property function, which defaults to true.

## Preview of Example
Here's a quick gif preview of using the new story with "people" nodes as not being able to have children, but the "role" nodes being able to. 

![childless-nodes](https://user-images.githubusercontent.com/15057490/45988611-a4285200-c02c-11e8-8867-3eff5f02ddf8.gif)
