### PR TITLE
Respect addAsFirstChild in addNodeUnderParent

### DIFF
--- a/src/utils/tree-data-utils.js
+++ b/src/utils/tree-data-utils.js
@@ -60,7 +60,7 @@ function getNodeDataAtTreeIndexOrNextIndex({
 export function getDescendantCount({ node, ignoreCollapsed = true }) {
   return (
     getNodeDataAtTreeIndexOrNextIndex({
-      getNodeKey: () => { },
+      getNodeKey: () => {},
       ignoreCollapsed,
       node,
       currentIndex: 0,
@@ -106,12 +106,12 @@ function walkDescendants({
   const selfInfo = isPseudoRoot
     ? null
     : {
-      node,
-      parentNode,
-      path: selfPath,
-      lowerSiblingCounts,
-      treeIndex: currentIndex,
-    };
+        node,
+        parentNode,
+        path: selfPath,
+        lowerSiblingCounts,
+        treeIndex: currentIndex,
+      };
 
   if (!isPseudoRoot) {
     const callbackResult = callback(selfInfo);
@@ -623,13 +623,13 @@ export function addNodeUnderParent({
   if (parentKey === null) {
     return addAsFirstChild
       ? {
-        treeData: [newNode, ...(treeData || [])],
-        treeIndex: 0,
-      }
+          treeData: [newNode, ...(treeData || [])],
+          treeIndex: 0,
+        }
       : {
-        treeData: [...(treeData || []), newNode],
-        treeIndex: (treeData || []).length,
-      };
+          treeData: [...(treeData || []), newNode],
+          treeIndex: (treeData || []).length,
+        };
   }
 
   let insertedTreeIndex = null;
@@ -892,7 +892,7 @@ export function insertNode({
   depth: targetDepth,
   minimumTreeIndex,
   newNode,
-  getNodeKey = () => { },
+  getNodeKey = () => {},
   ignoreCollapsed = true,
   expandParent = false,
 }) {
@@ -1100,9 +1100,9 @@ export function find({
     const extraInfo = isPseudoRoot
       ? null
       : {
-        path: selfPath,
-        treeIndex: currentIndex,
-      };
+          path: selfPath,
+          treeIndex: currentIndex,
+        };
 
     // Nodes with with children that aren't lazy
     const hasChildren =

--- a/src/utils/tree-data-utils.js
+++ b/src/utils/tree-data-utils.js
@@ -60,7 +60,7 @@ function getNodeDataAtTreeIndexOrNextIndex({
 export function getDescendantCount({ node, ignoreCollapsed = true }) {
   return (
     getNodeDataAtTreeIndexOrNextIndex({
-      getNodeKey: () => {},
+      getNodeKey: () => { },
       ignoreCollapsed,
       node,
       currentIndex: 0,
@@ -106,12 +106,12 @@ function walkDescendants({
   const selfInfo = isPseudoRoot
     ? null
     : {
-        node,
-        parentNode,
-        path: selfPath,
-        lowerSiblingCounts,
-        treeIndex: currentIndex,
-      };
+      node,
+      parentNode,
+      path: selfPath,
+      lowerSiblingCounts,
+      treeIndex: currentIndex,
+    };
 
   if (!isPseudoRoot) {
     const callbackResult = callback(selfInfo);
@@ -621,10 +621,15 @@ export function addNodeUnderParent({
   addAsFirstChild = false,
 }) {
   if (parentKey === null) {
-    return {
-      treeData: [...(treeData || []), newNode],
-      treeIndex: (treeData || []).length,
-    };
+    return addAsFirstChild
+      ? {
+        treeData: [newNode, ...(treeData || [])],
+        treeIndex: 0,
+      }
+      : {
+        treeData: [...(treeData || []), newNode],
+        treeIndex: (treeData || []).length,
+      };
   }
 
   let insertedTreeIndex = null;
@@ -887,7 +892,7 @@ export function insertNode({
   depth: targetDepth,
   minimumTreeIndex,
   newNode,
-  getNodeKey = () => {},
+  getNodeKey = () => { },
   ignoreCollapsed = true,
   expandParent = false,
 }) {
@@ -1095,9 +1100,9 @@ export function find({
     const extraInfo = isPseudoRoot
       ? null
       : {
-          path: selfPath,
-          treeIndex: currentIndex,
-        };
+        path: selfPath,
+        treeIndex: currentIndex,
+      };
 
     // Nodes with with children that aren't lazy
     const hasChildren =

--- a/src/utils/tree-data-utils.test.js
+++ b/src/utils/tree-data-utils.test.js
@@ -1927,9 +1927,9 @@ describe('map', () => {
           !node.children
             ? node
             : {
-              ...node,
-              children: node.children.sort((a, b) => a.key - b.key),
-            },
+                ...node,
+                children: node.children.sort((a, b) => a.key - b.key),
+              },
         treeData: [
           {
             key: 1,

--- a/src/utils/tree-data-utils.test.js
+++ b/src/utils/tree-data-utils.test.js
@@ -1145,6 +1145,20 @@ describe('addNodeUnderParent', () => {
     expect(expectedNewNode).toEqual(nestedParams.newNode);
     expect(previousChildren).toEqual(nestedParams.treeData[0].children);
   });
+
+  it('should add new node as first child under root if addAsFirstChild is true', () => {
+    const result = addNodeUnderParent({
+      ...nestedParams,
+      parentKey: null,
+      getNodeKey: keyFromKey,
+      addAsFirstChild: true,
+    });
+
+    const [expectedNewNode, ...previousTreeData] = result.treeData;
+
+    expect(expectedNewNode).toEqual(nestedParams.newNode);
+    expect(previousTreeData).toEqual(nestedParams.treeData);
+  });
 });
 
 describe('insertNode', () => {
@@ -1913,9 +1927,9 @@ describe('map', () => {
           !node.children
             ? node
             : {
-                ...node,
-                children: node.children.sort((a, b) => a.key - b.key),
-              },
+              ...node,
+              children: node.children.sort((a, b) => a.key - b.key),
+            },
         treeData: [
           {
             key: 1,


### PR DESCRIPTION
# Expected Behavior
When adding a new node to an existing treeData using `addNodeUnderParent`, I can get it to be the first element directly under root by passing `parentKey: null, addAsFirstChild: true`.

# Actual Behavior
The flag `addAsFirstChild` is not respected, the new node is always appended as last child.

# Steps to reproduce
```
    const result = addNodeUnderParent({
      treeData: [
        { key: 0, children: [] },
        { key: 6 },
      ],
      newNode: { key: 'new' },
      parentKey: null,
      getNodeKey: ({ node }) => node.key,
      addAsFirstChild: true,
    });
```