### PR TITLE
Add propTypes definition to pass latest eslint-plugin-react

### DIFF
--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -770,7 +770,9 @@ class ReactSortableTree extends Component {
 }
 
 ReactSortableTree.propTypes = {
-  dragDropManager: PropTypes.shape({}).isRequired,
+  dragDropManager: PropTypes.shape({
+    getMonitor: PropTypes.func,
+  }).isRequired,
 
   // Tree data in the following format:
   // [{title: 'main', subtitle: 'sub'}, { title: 'value2', expanded: true, children: [{ title: 'value3') }] }]


### PR DESCRIPTION
The latest eslint-plugin-react (@7.13.0) notice following violations.

```
% npm run lint
  150:8   error  'dragDropManager.getMonitor' is missing in props validation  react/prop-types
  227:48  error  'dragDropManager.getMonitor' is missing in props validation  react/prop-types

✖ 2 problems (2 errors, 0 warnings)
```

### Note
- 7.11.1 pass without violations
- 7.12.4 notice same violations

### Reproduce
1. Clone repository
2. `npm install`
3. `npm run lint`
