### PR TITLE
Disable dragging by Drag Source Specification on react-dnd

### DIFF
--- a/src/utils/dnd-manager.js
+++ b/src/utils/dnd-manager.js
@@ -183,6 +183,8 @@ export default class DndManager {
         this.endDrag(monitor.getDropResult());
       },
 
+      canDrag: props => props.canDrag,
+
       isDragging: (props, monitor) => {
         const dropTargetNode = monitor.getItem().node;
         const draggedNode = props.node;


### PR DESCRIPTION
When use some theme that can drag entire node, Can't disable draggable status dynamically by `canDrag` prop after enable.


### Reproduce code snippet
```
constructor() {
  this.state = {
    treeData: [
      { title: 'Title', draggable: false },
      ...
    ]
  }
}

render() {
  <SortableTree
    treeData={this.state.treeData}
    canDrag={({ node }) => node.draggable}
  />
}

toggleDraggable = ({ node, path }) => {
  const newNode = {
    ...node,
    draggable: !node.draggable
  }

  const newState = changeNodeAtPath({
    treeData: this.state.treeData,
    path,
    newNode,
    getNodeKey: ({ treeIndex }) => treeIndex
  })
  this.setState({ treeData: newState })
}
```

### Description
1. Render tree and can't drag node. (Correct behavior)
2. toggle dragging status.
3. can drag node. (Correct behavior)
4. toggle dragging status.
5. CAN drag node. (Wrong behavior)

### Reason
If turn on dragging feature, target node connect as drag source via `connectDragSource`.
This connecting status will NOT release when turn off feature.

### Resolve
This PR change to pass `canDrag` prop to `canDrag` property in drag source specification that is defined in `react-dnd`
http://react-dnd.github.io/react-dnd/docs/api/drag-source#specification-methods