### PR TITLE
Update README to reflect project requirements in contributor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,27 +197,27 @@ import { SortableTreeWithoutDndContext as SortableTree } from 'react-sortable-tr
 
 Please read the [Code of Conduct](CODE_OF_CONDUCT.md). I actively welcome pull requests :)
 
-After cloning the repository and running `npm install` inside, you can use the following commands to develop and build the project.
+After cloning the repository and running `yarn install` inside, you can use the following commands to develop and build the project.
 
 ```sh
 # Starts a webpack dev server that hosts a demo page with the component.
 # It uses react-hot-loader so changes are reflected on save.
-npm start
+yarn start
 
 # Start the storybook, which has several different examples to play with.
 # Also hot-reloaded.
-npm run storybook
+yarn run storybook
 
 # Runs the library tests
-npm test
+yarn test
 
 # Lints the code with eslint
-npm run lint
+yarn run lint
 
 # Lints and builds the code, placing the result in the dist directory.
 # This build is necessary to reflect changes if you're
 #  `npm link`-ed to this repository from another local project.
-npm run build
+yarn run build
 ```
 
 Pull requests are welcome!


### PR DESCRIPTION
Hi!

When working on another pull request, I noticed that the contributor section of the README doesn't reflect that the project is currently using [Yarn](https://yarnpkg.com/en/docs/usage), instead of NPM as a package manager. I ran into a few issues trying to use NPM until I noticed this. 

I updated the README to reflect this. Please let me know if there's anything else I should add!