### PR TITLE
Pass the path of the dragged node to the renderer. Useful for themes.

### DIFF
--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -541,7 +541,7 @@ class ReactSortableTree extends Component {
 
   renderRow(
     row,
-    { listIndex, style, getPrevRow, matchKeys, swapFrom, swapDepth, swapLength }
+    { listIndex, style, getPrevRow, matchKeys, swapFrom, swapDepth, swapLength, draggedNodePath }
   ) {
     const { node, parentNode, path, lowerSiblingCounts, treeIndex } = row;
 
@@ -592,6 +592,7 @@ class ReactSortableTree extends Component {
         swapFrom={swapFrom}
         swapLength={swapLength}
         swapDepth={swapDepth}
+        draggedNodePath={draggedNodePath}
         {...sharedProps}
       >
         <NodeContentRenderer
@@ -635,6 +636,7 @@ class ReactSortableTree extends Component {
     let rows;
     let swapFrom = null;
     let swapLength = null;
+    let draggedNodePath = null;
     if (draggedNode && draggedMinimumTreeIndex !== null) {
       const addedResult = memoizedInsertNode({
         treeData,
@@ -654,6 +656,7 @@ class ReactSortableTree extends Component {
         swapTo,
         swapLength
       );
+      draggedNodePath = addedResult.path;
     } else {
       rows = this.getRows(treeData);
     }
@@ -726,6 +729,7 @@ class ReactSortableTree extends Component {
                   swapFrom,
                   swapDepth: draggedDepth,
                   swapLength,
+                  draggedNodePath,
                 })
               }
               {...reactVirtualizedListProps}
@@ -754,6 +758,7 @@ class ReactSortableTree extends Component {
           swapFrom,
           swapDepth: draggedDepth,
           swapLength,
+          draggedNodePath,
         })
       );
     }


### PR DESCRIPTION
In working on a custom theme, I was tuning the highlighting to work up the antecedents and found that having access to path of the node being dragged helps to prune out subtrees that aren't involved in the parent hierarchy.

![drag_one](https://user-images.githubusercontent.com/4042399/65010957-da06ca80-d950-11e9-840c-6b7b40e0d9c0.png)

![drag_two](https://user-images.githubusercontent.com/4042399/65010963-df641500-d950-11e9-8081-37146c1ea90f.png)
