### PR TITLE
Add example for importing helper functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ Check out the helper functions exported from [`tree-data-utils.js`](https://gith
 - [**`isDescendant`**](https://github.com/frontend-collective/react-sortable-tree/blob/master/src/utils/tree-data-utils.js#L1027): Check if a node is a descendant of another node.
 - [**`getDepth`**](https://github.com/frontend-collective/react-sortable-tree/blob/master/src/utils/tree-data-utils.js#L1045): Get the longest path in the tree.
 
+You can import helpers via named imports. Example:
+```js
+import {removeNode} from 'react-sortable-tree';
+```
+
 ## Themes
 
 Using the `theme` prop along with an imported theme module, you can easily override the default appearance with another standard one.


### PR DESCRIPTION
I would like to propose adding an example of importing a helper since at the moment it may seem that helpers should be imported from the `tree-data-utils.js` file.