### PR TITLE
The subtitle value not positioned correctly when set from generateNodeProps 

### DIFF
--- a/src/node-renderer-default.js
+++ b/src/node-renderer-default.js
@@ -136,7 +136,7 @@ class NodeRendererDefault extends Component {
                   <span
                     className={classnames(
                       'rst__rowTitle',
-                      node.subtitle && 'rst__rowTitleWithSubtitle'
+                      nodeSubtitle && 'rst__rowTitleWithSubtitle'
                     )}
                   >
                     {typeof nodeTitle === 'function'

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -836,9 +836,14 @@ exports[`Storyshots Advanced Playing with generateNodeProps 1`] = `
                             className="rst__rowLabel"
                           >
                             <span
-                              className="rst__rowTitle"
+                              className="rst__rowTitle rst__rowTitleWithSubtitle"
                             >
                               Red Captain
+                            </span>
+                            <span
+                              className="rst__rowSubtitle"
+                            >
+                              Red Team
                             </span>
                           </div>
                           <div
@@ -909,9 +914,14 @@ exports[`Storyshots Advanced Playing with generateNodeProps 1`] = `
                             className="rst__rowLabel"
                           >
                             <span
-                              className="rst__rowTitle"
+                              className="rst__rowTitle rst__rowTitleWithSubtitle"
                             >
                               Black Captain
+                            </span>
+                            <span
+                              className="rst__rowSubtitle"
+                            >
+                              Black Team
                             </span>
                           </div>
                           <div
@@ -995,9 +1005,14 @@ exports[`Storyshots Advanced Playing with generateNodeProps 1`] = `
                             className="rst__rowLabel"
                           >
                             <span
-                              className="rst__rowTitle"
+                              className="rst__rowTitle rst__rowTitleWithSubtitle"
                             >
                               Green Captain
+                            </span>
+                            <span
+                              className="rst__rowSubtitle"
+                            >
+                              Green Team
                             </span>
                           </div>
                           <div

--- a/stories/generate-node-props.js
+++ b/stories/generate-node-props.js
@@ -54,6 +54,7 @@ export default class App extends Component {
                 title: `${playerColor} ${
                   path.length === 1 ? 'Captain' : node.position
                 }`,
+                subtitle: `${playerColor} Team`,
                 onClick: () => {
                   this.setState(state => ({
                     treeData: changeNodeAtPath({


### PR DESCRIPTION
Add class consistently to node when subtitle exists regardless of if subtitle value has been overriden with generateNodeProps.

The 'rst__rowTitleWithSubtitle' class was only being added when the subtitle came through on the node prop. When subtitle was passed in explicitly as a prop to the component it was not being added.

**Before:**
![image](https://user-images.githubusercontent.com/13750283/75327411-3f51d680-5874-11ea-8295-1e7acbab661c.png)


**After:**
![image](https://user-images.githubusercontent.com/13750283/75327337-234e3500-5874-11ea-8f33-747e1ffa2663.png)
