### PR TITLE
Pass current treeData to canDrop callback

### DIFF
--- a/src/utils/dnd-manager.js
+++ b/src/utils/dnd-manager.js
@@ -150,6 +150,7 @@ export default class DndManager {
         nextPath: addedResult.path,
         nextParent: addedResult.parentNode,
         nextTreeIndex: addedResult.treeIndex,
+        treeData: this.treeData
       });
     }
 


### PR DESCRIPTION
Hi,

currently the prevTreeIndex, nextTreeIndex indices are wrong when nodes are expande during the dragging operation (hovering over closed node). The changes are internally reflected in the treeData structure, but not yet published (via onChange or onVisibilityToggle). This breaks all invocations of getVisibleNodeInfoAtIndex when using f.ex. nextTreeIndex.

To mitigate the issue, the current treeData structure is passed to the canDrop callback.

Thanks for your work!
