### PR TITLE
Exposing react-virtualized row props

### DIFF
--- a/src/node-renderer-default.js
+++ b/src/node-renderer-default.js
@@ -30,6 +30,12 @@ class NodeRendererDefault extends Component {
       isOver, // Not needed, but preserved for other renderers
       parentNode, // Needed for dndManager
       rowDirection,
+
+      // virtualized row props
+      isScrolling,
+      isVisible,
+      parent,
+
       ...otherProps
     } = this.props;
     const nodeTitle = title || node.title;
@@ -194,6 +200,9 @@ NodeRendererDefault.defaultProps = {
   title: null,
   subtitle: null,
   rowDirection: 'ltr',
+  isScrolling: false,
+  isVisible: true,
+  parent: {},
 };
 
 NodeRendererDefault.propTypes = {
@@ -228,6 +237,11 @@ NodeRendererDefault.propTypes = {
 
   // rtl support
   rowDirection: PropTypes.string,
+
+  // virtualized row props
+  isScrolling: PropTypes.bool,
+  isVisible: PropTypes.bool,
+  parent: PropTypes.shape({}),
 };
 
 export default NodeRendererDefault;

--- a/src/react-sortable-tree.js
+++ b/src/react-sortable-tree.js
@@ -542,7 +542,7 @@ class ReactSortableTree extends Component {
 
   renderRow(
     row,
-    { listIndex, style, getPrevRow, matchKeys, swapFrom, swapDepth, swapLength }
+    { listIndex, style, getPrevRow, matchKeys, swapFrom, swapDepth, swapLength, ...rowProps }
   ) {
     const { node, parentNode, path, lowerSiblingCounts, treeIndex } = row;
 
@@ -603,6 +603,7 @@ class ReactSortableTree extends Component {
           toggleChildrenVisibility={this.toggleChildrenVisibility}
           {...sharedProps}
           {...nodeProps}
+          {...rowProps}
         />
       </TreeNodeRenderer>
     );
@@ -718,7 +719,7 @@ class ReactSortableTree extends Component {
                         path: rows[index].path,
                       })
               }
-              rowRenderer={({ index, style: rowStyle }) =>
+              rowRenderer={({ index, style: rowStyle, ...rowProps }) =>
                 this.renderRow(rows[index], {
                   listIndex: index,
                   style: rowStyle,
@@ -727,6 +728,7 @@ class ReactSortableTree extends Component {
                   swapFrom,
                   swapDepth: draggedDepth,
                   swapLength,
+                  ...rowProps,
                 })
               }
               {...reactVirtualizedListProps}


### PR DESCRIPTION
This PR exposes `react-virtualized` rowRenderer props such as `isScrolling` and `isVisible`.
This allows theme developers to add UI specific to scrolling and in addition, address performance issues with the `isVisible` flag.

Cross merge with: https://github.com/frontend-collective/react-sortable-tree-theme-file-explorer/pull/30