### PR TITLE
Fixed bug when specifying own subtitle property.

### DIFF
--- a/src/node-renderer-default.js
+++ b/src/node-renderer-default.js
@@ -136,7 +136,7 @@ class NodeRendererDefault extends Component {
                   <span
                     className={classnames(
                       'rst__rowTitle',
-                      node.subtitle && 'rst__rowTitleWithSubtitle'
+                      nodeSubtitle && 'rst__rowTitleWithSubtitle'
                     )}
                   >
                     {typeof nodeTitle === 'function'


### PR DESCRIPTION
One hard reference to node.subtitle was left behind which causes a formatting issue when specifying your own subtitle.