### PR TITLE
getTreeFromFlatData prevent children to be overriden in trav function

### DIFF
--- a/src/utils/tree-data-utils.js
+++ b/src/utils/tree-data-utils.js
@@ -1009,9 +1009,15 @@ export function getTreeFromFlatData({
   const trav = parent => {
     const parentKey = getKey(parent);
     if (parentKey in childrenToParents) {
+      let children;
+      if (parent.hasOwnProperty('children') && parent.children.length > 0) {
+        children = [...parent.children, ...childrenToParents[parentKey].map(child => trav(child))];
+      } else {
+        children = childrenToParents[parentKey].map(child => trav(child));
+      }
       return {
         ...parent,
-        children: childrenToParents[parentKey].map(child => trav(child)),
+        children
       };
     }
 


### PR DESCRIPTION
getTreeFromFlatData() the children property when the root parent has children where one of them can be subParent. for example where folder has many reports and subFolder which has its own reports.

When flat list item parentId refers to id of another item in the flat list but it also has children property and value of its own, it should be added to the children list instead of overriding it.


```
[
   {
      "children": [
         {
            "id": 2,
            "name": "Active pr-locs",
            "folderId": 4
         },
         {
            "id": 11,
            "name": "MRP,CO-MRP,K-TP not in assortment",
            "folderId": 4
         }
      ],
      "id": 4,
      "parentId": 0
   },
   {
      "children": [
         {
            "id": 17,
            "name": "search criteria",
            "folderId": 6
         },
         {
            "id": 19,
            "name": "dashboard2 drill2d and view",
            "folderId": 6
         },
      ],
      "id": 6,
      "parentId": 0
   },
   {
      "children": [
         {
            "id": 35,
            "name": "New view",
            "folderId": 7
         },
         {
            "id": 39,
            "name": "New view",
            "folderId": 7
         }
      ],
      "id": 7,
      "parentId": 0
   },
   {
      "children": [
         {
            "id": 38,
            "name": "New view",
            "folderId": 8
         }
      ],
      "id": 8,
      "parentId": 7
   }
]
```