### PR TITLE
Hover/drop race conditions

### DIFF
--- a/src/utils/dnd-manager.js
+++ b/src/utils/dnd-manager.js
@@ -235,9 +235,14 @@ export default class DndManager {
         // throttle `dragHover` work to available animation frames
         cancelAnimationFrame(this.rafId);
         this.rafId = requestAnimationFrame(() => {
+          const item = monitor.getItem()
+          // skip if drag already ended before the animation frame
+          if (!item || !monitor.isOver()) {
+            return;
+          }
           this.dragHover({
             node: draggedNode,
-            path: monitor.getItem().path,
+            path: item.path,
             minimumTreeIndex: dropTargetProps.listIndex,
             depth: targetDepth,
           });


### PR DESCRIPTION
I think I've found two race conditions where dragging nodes too quickly results in errors.

Case 1: `Uncaught TypeError: Cannot read property 'path' of null at dnd-manager.js:240`

How to reproduce:
- Open the "Minimal implementation" storybook in Chrome (I have reproduced this in Firefox, too, but it's a lot trickier)
- Enable 6x slowdown CPU throttling from DevTools 
- Drag-and-drop the nodes around, trying to keep each drag as quick as possible
- Eventually you'll get error (in DevTools console) `"Uncaught TypeError: Cannot read property 'path' of null at dnd-manager.js:240"`

Apparently what happens is that the animation frame code gets called after the drag is already over, and `monitor.getItem()` returns `null`.

Case 2: `Encountered two children with the same key` warning from React

How to reproduce:
- Open the "Callbacks" storybook (important: it has `getNodeKey` which uses ids) with Chrome
- Enable 6x slowdown CPU throttling from DevTools 
- Drag-and-drop the nodes around, trying to keep each drag as quick as possible
- Eventually you'll get `Warning: Encountered two children with the same key, 'nodeA'.` from React

It looks like drop has been called (so the dragged node has been added back to tree), but after the same animation frame code runs, "draggedNode" is set to the already-dropped node... which is then rendered again, and for a short duration (not visible), there are two nodes with same key in the tree...
